### PR TITLE
Feature/omniauth attribute mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ module OpenProject::SomeAuthPlugin
             port: '692',
             #, ... more provider options
             display_name: 'Provider 2'
+            # ... provide custom attribute mapping
+            openproject_attribute_map: Proc.new {|auth| { login: auth[:info][:uid] } }
           }
         ]
       end
@@ -69,6 +71,12 @@ In the example our own plugin provides the icon. In the plugin's directory it ha
 **Additional provider attribute `display_name`**
 
 Another extra attribute shown is `display_name`. While `name` is used to identify the provider in URLs `display_name` is what is shown to the user.
+
+**Additional provider attribute `openproject_attribute_map`**
+
+To provide a custom user attribute mapping for this strategy, you may optionally specify a block that returns an attribute mapping hash. In the examplary strategy *another_provider*, the OpenProject attribute `:login` is overridden reflect the attribute `:uid` from the strategy.
+
+The block is called with the [OmniAuth AuthHash object](https://github.com/intridea/omniauth/wiki/Auth-Hash-Schema). You can use the `:extra` key to access the raw attributes as returned from the authentication schema.
 
 ## OpenProject Integration
 

--- a/lib/omniauth/flexible_strategy.rb
+++ b/lib/omniauth/flexible_strategy.rb
@@ -60,6 +60,14 @@ module OmniAuth
       @provider
     end
 
+    def omniauth_hash_to_user_attributes(auth)
+      if options.key?(:openproject_attribute_map)
+        options[:openproject_attribute_map].call(auth)
+      else
+        {}
+      end
+    end
+
     def path_for_provider(name)
       "#{path_prefix}/#{name}"
     end


### PR DESCRIPTION
OpenProject currently employs a fixed attribute mapping schema for
userdata extracted from OmniAuth::AuthHash.

This feature adds an override to user attributes optionally defined within
each strategy plugin.
It requires a tiny counterpart change in OpenProject's `Concerns::OmniAuth` to call the strategy override, if it exists. See the accompanying pull request at [https://github.com/opf/openproject/pull/2062](https://github.com/opf/openproject/pull/2062)

Motivation for implementation choices:
1. **The attribute mapping is included in the strategy options**.  This reduces changes to the FlexibleStrategy to a minimum and at the same time, allows different mappings for each provider, even if the underlying strategy is identical.
2. **The attribute mapping is a block, called with the OmniAuth userdata** `OmniAuth::AuthHash`. This allows users to access raw attributes returned from the authentication scheme (in my use-case: LDAP). This would be cumbersome with only a simple hash mapping. However, it would be conceivable to allow blocks and hashes for simpler uses.
- [The corresponding Pull Request at opf/openproject](https://github.com/opf/openproject/pull/2062)
- [The respective discussion in the boards can be found here](https://community.openproject.org/topics/3107)
- [The corresponding work package](https://community.openproject.org/work_packages/16841)
