### PR TITLE
exit early if no auth request

### DIFF
--- a/lib/omniauth/flexible_strategy.rb
+++ b/lib/omniauth/flexible_strategy.rb
@@ -40,7 +40,7 @@ module OmniAuth
 
   module FlexibleStrategy
     def on_auth_path?
-      (match_provider! || false) && super
+      !not_on_auth_path? && (match_provider! || false) && super
     end
 
     ##
@@ -70,6 +70,14 @@ module OmniAuth
 
     def path_for_provider(name)
       "#{path_prefix}/#{name}"
+    end
+
+    ##
+    # This method returning false does not mean that the current request should be handled by
+    # this strategy. The method can, however, indicate that a request should NOT be handled by it.
+    # In which case it returns true.
+    def not_on_auth_path?
+      (current_path =~ /#{path_prefix}/) != 0
     end
 
     def providers

--- a/lib/omniauth/flexible_strategy.rb
+++ b/lib/omniauth/flexible_strategy.rb
@@ -40,7 +40,7 @@ module OmniAuth
 
   module FlexibleStrategy
     def on_auth_path?
-      !not_on_auth_path? && (match_provider! || false) && super
+      possible_auth_path? && (match_provider! || false) && super
     end
 
     ##
@@ -73,11 +73,10 @@ module OmniAuth
     end
 
     ##
-    # This method returning false does not mean that the current request should be handled by
-    # this strategy. The method can, however, indicate that a request should NOT be handled by it.
-    # In which case it returns true.
-    def not_on_auth_path?
-      (current_path =~ /#{path_prefix}/) != 0
+    # Returns true if the current path could be an authentication request,
+    # false otherwise (e.g. for resources).
+    def possible_auth_path?
+      current_path =~ /\A#{path_prefix}/
     end
 
     def providers


### PR DESCRIPTION
don't re-evaluate available providers for requests that are certainly no authentication requests (such as resources)
