### PR TITLE
use getter...

### DIFF
--- a/lib/omniauth/flexible_strategy.rb
+++ b/lib/omniauth/flexible_strategy.rb
@@ -47,7 +47,7 @@ module OmniAuth
     # Tries to match the request path of the current request with one of the registered providers.
     # If a match is found the strategy is intialised with that provider to handle the request.
     def match_provider!
-      return false unless @providers
+      return false unless providers
 
       @provider = providers.find do |p|
         (current_path =~ /#{path_for_provider(p.to_hash[:name])}/) == 0
@@ -94,7 +94,6 @@ module OmniAuth
     def dup
       super.tap do |s|
         s.extend FlexibleStrategy
-        s.providers = providers
       end
     end
   end


### PR DESCRIPTION
dunno what I was thinking

The providers are reevaluated even in unrelated requests because the middleware is copied around all the time (#dup). Dup sets the providers. Why?
Because silly me used the instance variable directly above in #match_provider! and it wasn't properly set after copying the strategy.
